### PR TITLE
fix blank column and update attendees mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ If you want to add a conference, feel encouraged to create a PR which adds the c
 
 ## Upcoming Flutter conferences
 
-| Name                               | Date                               | CfP-Link                    | CfP-Deadline-Date | Place                   | Aprox. Attendees |     |          |
-| ---------------------------------- | ---------------------------------- | --------------------------- | ----------------- | ----------------------- | ---------------- | --- | -------- |
-| [Flutter MENA][1] 2024             | April 26, 2024                     | --                          | --                | [Online][27]            |                  |     |          |
-| [Full Stack Flutter][3] 2024       | May 28, 2024                       | [Full Stack Flutter CfP][4] | April 4th, 2024   | Online                  | 1000+            |     |          |
-| [FlutterNinjas][5] 2024            | June 14-15, 2024                   | [FlutterNinjas CfP][6]      | April 17th, 2024  | Tokyo, Japan            | ???              |     |          |
-| [Fluttercon EU][7] 2024            | July 3rd - 5th, 2024               | [Fluttercon EU 2024][8]     | May 1st, 2024     | Berlin, Germany         | 1000+            |     |          |
-| [Flutter & Friends][9] 2024        | September 1st - 3rd, 2024          | [Flutter & Friends CFP][10] | June 1st, 2024    | Stockholm, Sweden       | 250+             |     |          |
-| [Fluttercon USA 2024][11]          | September 19th - 20th, 2024        | tba                         | tba               | New York City, New York | 700+             |     |          |
-| [FlutterBytes Conference][12] 2024 | tba (around October/November 2024) | tba                         | tba               | Lagos, Nigeria          | 500+             |     |          |
-| [FlutterConf Latam][13] 2024       | October 29th - 30th, 2024          | tba                         | tba               | Arequipa, Perú          | 300 - 500        |     |          |
-| [droidcon London][14] 2024         | 31.10 - 01.11 2024                 | tba                         | tba               | London, UK              | 1000+            |     |          |
-| [Droid+FlutterCon Kenya][29] 2024  | November 6-8th, 2024               | [Droidcon Kenya][28]        | July 31st, 2024   | Nairobi, Kenya          | 500+             |     |          |
-| [Flutter Conf India][15] 2024      | November, 2024                     | tba                         | tba               | tba, India              | 500-1000         |     |          |
-| [droidcon Italy][16] 2024          | November, 2024                     | tba                         | tba               | Milan, Italy            |                  |     | 500-1000 |
+| Name                               | Date                               | CfP-Link                    | CfP-Deadline-Date | Place                   | Aprox. Attendees |
+| ---------------------------------- | ---------------------------------- | --------------------------- | ----------------- | ----------------------- | ---------------- |
+| [Flutter MENA][1] 2024             | April 26, 2024                     | --                          | --                | [Online][27]            |                  |
+| [Full Stack Flutter][3] 2024       | May 28, 2024                       | [Full Stack Flutter CfP][4] | April 4th, 2024   | Online                  | 1000+            |
+| [FlutterNinjas][5] 2024            | June 14-15, 2024                   | [FlutterNinjas CfP][6]      | April 17th, 2024  | Tokyo, Japan            | ???              |
+| [Fluttercon EU][7] 2024            | July 3rd - 5th, 2024               | [Fluttercon EU 2024][8]     | May 1st, 2024     | Berlin, Germany         | 1000+            |
+| [Flutter & Friends][9] 2024        | September 1st - 3rd, 2024          | [Flutter & Friends CFP][10] | June 1st, 2024    | Stockholm, Sweden       | 250+             |
+| [Fluttercon USA 2024][11]          | September 19th - 20th, 2024        | tba                         | tba               | New York City, New York | 700+             |
+| [FlutterBytes Conference][12] 2024 | tba (around October/November 2024) | tba                         | tba               | Lagos, Nigeria          | 500+             |
+| [FlutterConf Latam][13] 2024       | October 29th - 30th, 2024          | tba                         | tba               | Arequipa, Perú          | 300 - 500        |
+| [droidcon London][14] 2024         | 31.10 - 01.11 2024                 | tba                         | tba               | London, UK              | 1000+            |
+| [Droid+FlutterCon Kenya][29] 2024  | November 6-8th, 2024               | [Droidcon Kenya][28]        | July 31st, 2024   | Nairobi, Kenya          | 500+             |
+| [Flutter Conf India][15] 2024      | November, 2024                     | tba                         | tba               | tba, India              | 500-1000         |
+| [droidcon Italy][16] 2024          | November, 2024                     | tba                         | tba               | Milan, Italy            | 500-1000         |
 
 ## Past Flutter conferences
 


### PR DESCRIPTION
there is a blank column and the last conf was with the attendees number on mismatch column 
![Captura de tela 2024-05-03 104359](https://github.com/m-theis/flutter_conferences/assets/35867294/85b0af52-ecf4-4d2a-a2e7-42d4df40c5e5)
![Captura de tela 2024-05-03 104751](https://github.com/m-theis/flutter_conferences/assets/35867294/5e37c7df-46ef-4561-acfe-b603b251437a)
